### PR TITLE
Fix responseHandler function

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -42,7 +42,7 @@ const responseHandler = res => {
     return
   }
 
-  const marketName = res.url.includes(FUTURES) ? 'futures' : 'spot'
+  const marketName = res.url.includes('future') ? 'futures' : 'spot'
 
   Object.keys(headersMapping).forEach(key => {
     const outKey = headersMapping[key]


### PR DESCRIPTION
Change the URL check to match the key, not the URL of the mainnet futures to fix a bug when using the testnet url 'https://testnet.binancefuture.com'