### PR TITLE
Fix minimum notional value filter definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -994,7 +994,7 @@ declare module 'binance-api-node' {
 
   export interface SymbolMinNotionalFilter {
     filterType: SymbolFilterType.MIN_NOTIONAL
-    notional: string
+    minNotional: string
   }
 
   export interface SymbolMaxNumOrdersFilter {


### PR DESCRIPTION
The bug was introduced in #536 and falsly renamed `minNotional` to `notional`. I am changing it back as per [documentation of Binance](https://binance-docs.github.io/apidocs/spot/en/#filters):

![image](https://user-images.githubusercontent.com/469989/204154794-a3311dde-11c8-4bb5-9392-0d9eae9e45b3.png)

