### PR TITLE
Add `symbol` parameter to `exchangeInfo` function in index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -462,7 +462,7 @@ declare module 'binance-api-node' {
     }): Promise<AggregatedTrade[]>
     allBookTickers(): Promise<{ [key: string]: Ticker }>
     book(options: { symbol: string; limit?: number }): Promise<OrderBook>
-    exchangeInfo(): Promise<ExchangeInfo>
+    exchangeInfo(options?: { symbol: string }): Promise<ExchangeInfo>
     lendingAccount(options?: { useServerTime: boolean }): Promise<LendingAccount>
     fundingWallet(options?: {
       asset?: string


### PR DESCRIPTION
I added the `symbol` parameter to the `exchangeInfo` function types. The documentation says that this parameter is accepted, but it is not described in the types
Link to documentation:
https://www.npmjs.com/package/binance-api-node#exchangeinfo