### PR TITLE
Add the fields trailingDelta & trailingTime to executionReport object

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -628,6 +628,7 @@ const userTransforms = {
     price: m.p,
     executionType: m.x,
     stopPrice: m.P,
+    trailingDelta: m.d,
     icebergQuantity: m.F,
     orderStatus: m.X,
     orderRejectReason: m.r,
@@ -646,6 +647,7 @@ const userTransforms = {
     orderListId: m.g,
     quoteOrderQuantity: m.Q,
     lastQuoteTransacted: m.Y,
+    trailingTime: m.D,
   }),
   listStatus: m => ({
     eventType: 'listStatus',


### PR DESCRIPTION
This PR adds the missing fields `trailingDelta` & `trailingTime` to the transformed websocket message object of type `executionReport`.

For details, see: https://binance-docs.github.io/apidocs/spot/en/#payload-order-update