### PR TITLE
Fix payload type for futuresUserTrades

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -624,7 +624,7 @@ declare module 'binance-api-node' {
     }): Promise<AggregatedTrade[]>
     futuresTrades(options: { symbol: string; limit?: number }): Promise<TradeResult[]>
     futuresUserTrades(options: {
-      symbol: string
+      symbol?: string
       startTime?: number
       endTime?: number
       fromId?: number

--- a/index.d.ts
+++ b/index.d.ts
@@ -1069,6 +1069,8 @@ declare module 'binance-api-node' {
     ocoAllowed: boolean
     orderTypes: T[]
     permissions: TradingType_LT[]
+    pricePrecision:number,
+    quantityPrecision:number
     quoteAsset: string
     quoteAssetPrecision: number
     quoteCommissionPrecision: number


### PR DESCRIPTION
Symbol is not required in the Binance API. It is importand because if I want all my trades in the last week, i have to make one call for every single symbol instead of not sending symbol and get all of then all in once.