### PR TITLE
TimeInForce GTE_GTC added to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1409,12 +1409,13 @@ declare module 'binance-api-node' {
     FULL = 'FULL',
   }
 
-  export type TimeInForce_LT = 'GTC' | 'IOC' | 'FOK'
+  export type TimeInForce_LT = 'GTC' | 'IOC' | 'FOK' | 'GTE_GTC'
 
   export const enum TimeInForce {
     GTC = 'GTC',
     IOC = 'IOC',
     FOK = 'FOK',
+    GTE_GTC = 'GTE_GTC'
   }
 
   export type OrderRejectReason_LT =


### PR DESCRIPTION
TimeInForce GTE_GTC added to types

```
File: ./node_modules/binance-api-node/index.d.ts
Line 1412 : 
  export type TimeInForce_LT = 'GTC' | 'IOC' | 'FOK' | 'GTE_GTC'

  export const enum TimeInForce {
    GTC = 'GTC',
    IOC = 'IOC',
    FOK = 'FOK',
    GTE_GTC = 'GTE_GTC'
  }
```