### PR TITLE
Add quantityto trailing stop market new futures order

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1163,6 +1163,8 @@ declare module 'binance-api-node' {
 
   export interface TrailingStopMarketNewFuturesOrder extends NewFuturesOrderBase {
     type: 'TRAILING_STOP_MARKET'
+      
+    quantity?:string
     // default as the latest price(supporting different workingType)
     activationPrice?: string
     // min 0.1, max 5 where 1 for 1%

--- a/index.d.ts
+++ b/index.d.ts
@@ -624,7 +624,7 @@ declare module 'binance-api-node' {
     }): Promise<AggregatedTrade[]>
     futuresTrades(options: { symbol: string; limit?: number }): Promise<TradeResult[]>
     futuresUserTrades(options: {
-      symbol: string
+      symbol?: string
       startTime?: number
       endTime?: number
       fromId?: number

--- a/index.d.ts
+++ b/index.d.ts
@@ -1069,6 +1069,8 @@ declare module 'binance-api-node' {
     ocoAllowed: boolean
     orderTypes: T[]
     permissions: TradingType_LT[]
+    pricePrecision:number,
+    quantityPrecision:number
     quoteAsset: string
     quoteAssetPrecision: number
     quoteCommissionPrecision: number


### PR DESCRIPTION
The Binance API allows to send the quantity param and it is missing in the type. 