### PR TITLE
Add endpoint marginGetOrderOco

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Following examples will use the `await` form, which requires some configuration 
   - [marginOrder](#marginOrder)
   - [marginOrderOco](#marginOrderOco)
   - [marginGetOrder](#marginGetOrder)
+  - [marginGetOrderOco](#marginGetOrderOco)
   - [disableMarginAccount](#disableMarginAccount)
   - [enableMarginAccount](#enableMarginAccount)
 - [Portfolio Margin](#portfolio-margin)
@@ -3329,6 +3330,55 @@ console.log(await client.marginGetOrder({
 }
 ```
 
+</details>
+
+#### marginGetOrderOco
+
+Retrieves a specific Margin OCO based on provided optional parameters
+
+```js
+console.log(
+  await client.getMarginOrderOco({
+    orderListId: 27,
+  }),
+)
+```
+
+| Param             | Type   | Required | Description                                 |
+| ----------------- | ------ | -------- | ------------------------------------------- |
+| orderListId       | Number | true     | Not required if `listClientOrderId` is used |
+| symbol            | Boolean| false    | mandatory for isolated margin, not supported for cross margin
+| isIsolated        | Boolean| false    |
+| listClientOrderId | String | false    |
+| recvWindow        | Number | false    |
+
+<details>
+<summary>Output</summary>
+
+```js
+{
+  orderListId: 27,
+  contingencyType: 'OCO',
+  listStatusType: 'EXEC_STARTED',
+  listOrderStatus: 'EXECUTING',
+  listClientOrderId: 'h2USkA5YQpaXHPIrkd96xE',
+  transactionTime: 1565245656253,
+  symbol: 'LTCBTC',
+  isIsolated: false,
+  orders: [
+    {
+      symbol: 'LTCBTC',
+      orderId: 4,
+      clientOrderId: 'qD1gy3kc3Gx0rihm9Y3xwS'
+    },
+    {
+      symbol: 'LTCBTC',
+      orderId: 5,
+      clientOrderId: 'ARzZ9I00CPM8i3NhmU9Ega'
+    }
+  ]
+}
+```
 </details>
 
 ### Portfolio Margin Endpoints

--- a/index.d.ts
+++ b/index.d.ts
@@ -750,6 +750,13 @@ declare module 'binance-api-node' {
       origClientOrderId?: string
       recvWindow?: number
     }): Promise<Order>
+    marginGetOrderOco(options: {
+      symbol: string
+      isIsolated?: string | boolean
+      orderId?: string
+      origClientOrderId?: string
+      recvWindow?: number
+    }): Promise<QueryOrderOcoResult>
     marginAllOrders(options: {
       symbol: string
       useServerTime?: boolean
@@ -1902,6 +1909,18 @@ declare module 'binance-api-node' {
     listClientOrderId: string
     transactionTime: number
     symbol: string
+    orders: Order[]
+  }
+
+  export interface QueryMarginOrderOcoResult {
+    orderListId: number
+    contingencyType: OcoOrderType.CONTINGENCY_TYPE
+    listStatusType: ListStatusType_LT
+    listOrderStatus: ListOrderStatus_LT
+    listClientOrderId: string
+    transactionTime: number
+    symbol: string
+    isIsolated: Boolean
     orders: Order[]
   }
 

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -437,6 +437,7 @@ export default opts => {
     marginOrder: payload => order(privCall, payload, '/sapi/v1/margin/order'),
     marginOrderOco: payload => orderOco(privCall, payload, '/sapi/v1/margin/order/oco'),
     marginGetOrder: payload => privCall('/sapi/v1/margin/order', payload),
+    marginGetOrderOco: payload => privCall('/sapi/v1/margin/orderList', payload),
     marginCancelOrder: payload => privCall('/sapi/v1/margin/order', payload, 'DELETE'),
     marginOpenOrders: payload => privCall('/sapi/v1/margin/openOrders', payload),
     marginAccountInfo: payload => privCall('/sapi/v1/margin/account', payload),


### PR DESCRIPTION
Hello,

This PR introduces the marginGetOrderOco endpoint to the wrapper, providing functionality for accessing OCO orders for margin accounts. I've thoroughly tested this addition, and it functions as expected.

Updates include:

Addition of marginGetOrderOco endpoint to the wrapper
Documentation update in the README for easy reference

Thank you for reviewing! I appreciate your consideration for merging this work. 🙏
